### PR TITLE
Add token param when initialize subsonic

### DIFF
--- a/lib/subsonic.js
+++ b/lib/subsonic.js
@@ -61,7 +61,7 @@ Subsonic.SubsonicResource = require('./subsonicResource');
  * @param {string} salt random string must be at least 6 characters (e.g. 'c19b2d')
  * @param {string|ServerArgs} config ServerArgs object or url string
  */
-function Subsonic(username, token, salt, config) {
+function Subsonic(username, token, salt, config, password) {
   if (!(this instanceof Subsonic)) {
     return new Subsonic(...arguments);
   }
@@ -81,6 +81,7 @@ function Subsonic(username, token, salt, config) {
     username: username,
     token: token,
     salt: salt,
+    password: password,
   };
 
   this._prepResources();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -101,6 +101,7 @@ function buildBaseSearchParams(api) {
     u: api._getApiField('username'),
     t: api._getApiField('token'),
     s: api._getApiField('salt'),
+    p: api._getApiField('password'),
   };
 }
 


### PR DESCRIPTION
Hi!

Subsonic have a parameter call `t` which is the pregenerated MD5 token. 

I adding this feature to beable to connect to subsonic compatibe software call Funkwhale.

Feel free to merge / edit this PR if needed!

Thanks!