### PR TITLE
Fix port not being considered

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,7 +22,8 @@ function createRequest(api, params, args) {
   }
   const protocol = api._getApiField('protocol');
   const host = api._getApiField('host');
-  const path = `${buildBaseUrl(protocol, host)}/${params.path}`;
+  const port = api._getApiField('port');
+  const path = `${buildBaseUrl(protocol, host, port)}/${params.path}`;
   const headers = api._getApiField('headers');
   const reqObj = {
     method: params.method,
@@ -115,9 +116,10 @@ function buildBaseSearchParams(api) {
   };
 }
 
-function buildBaseUrl(protocol, host) {
+function buildBaseUrl(protocol, host, port) {
   protocol = host.indexOf('http') > -1 ? '' : protocol;
-  host = host[host.length - 1] !== '/' ? `${host}/rest` : `${host}rest`;
+  if (port == 80 || port == 443) port = null;
+  host = host.replace(/\/$/, '') + (port ? `:${port}` : '') + '/rest';
   return protocol.length > 0 ? `${protocol}://${host}` : host;
 }
 


### PR DESCRIPTION
Upon building of the base URL the port is currently completely ignored. If the server is hosted on a non-default port, there is no way to connect.

I added the port into the base URL while ignoring the default ports 80 and 443.